### PR TITLE
feat(options): add options in rc file

### DIFF
--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -162,6 +162,25 @@ MultiReporters.prototype.getCustomOptions = function (options) {
     }
     else {
         customOptions = _.get(options, "reporterOptions");
+        if(!customOptions) {
+            customOptions = Object.keys(options)
+                .filter(function(key) { return key.indexOf('reporterOptions.') === 0; })
+                .reduce(function(obj, cur) {
+                    var parts = cur.split('.');
+                    parts.shift();
+                    var target = parts.pop();
+                    var curObj = obj;
+                    for(var i = 0; i < parts.length; i++) {
+                        var part = parts[i];
+                        if(!curObj.hasOwnProperty(parts)) {
+                            curObj[part] = {};
+                        }
+                        curObj = curObj[part];
+                    }
+                    curObj[target] = options[cur];
+                    return obj;
+                }, {});
+        }
     }
 
     return customOptions;


### PR DESCRIPTION
This allows for configuration options to be set in .mocharc.json. ex:
```JSON
{
    "reporter": "cypress-multi-reporters",
    "reporterOptions": {
        "reporterEnabled": "spec,mocha-junit-reporter",
        "mochaJunitReporterReporterOptions": {
            "mochaFile": "test-results.xml"
        }
    },
}
```