### PR TITLE
Ensure Mocha always gets found

### DIFF
--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -19,7 +19,7 @@ var mocha6plus;
 
 try {
   var json = JSON.parse(
-    fs.readFileSync("./node_modules/mocha/package.json", "utf8")
+    fs.readFileSync(path.dirname(require.resolve('mocha')) + "/package.json", "utf8")
   );
   version = json.version;
   if (version >= "6") {


### PR DESCRIPTION
Hello!

Thank you for this handy reporter. At the moment, it suffers from the same minor issue than `mocha-junit-reporter` used to: https://github.com/cypress-io/cypress/issues/4602.

This pull-request issues the same fix as for `mocha-junit-reporter`: https://github.com/michaelleeallen/mocha-junit-reporter/pull/88/files.

Thank you for considering it. :)