### PR TITLE
Array options

### DIFF
--- a/.ncurc.js
+++ b/.ncurc.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  // Whitelist all for checking besides `peer` which indicates
+  //   somewhat older versions of `eslint` we still support even
+  //   while our devDeps point to a more recent version
+  "dep": "prod,dev,optional,bundle"
+};

--- a/lib/MultiReporters.js
+++ b/lib/MultiReporters.js
@@ -46,7 +46,12 @@ function MultiReporters(runner, options) {
     if (_.get(options, 'execute', true)) {
         options = this.getOptions(options);
 
-        this._reporters = _.get(options, 'reporterEnabled', 'tap').split(',').map(
+        let enabledReporters = _.get(options, 'reporterEnabled', 'tap');
+        if (!Array.isArray(enabledReporters)) {
+            enabledReporters = enabledReporters.split(',');
+        }
+
+        this._reporters = enabledReporters.map(
             function processReporterEnabled(name, index) {
                 debug(name, index);
 
@@ -137,7 +142,7 @@ MultiReporters.prototype.getOptions = function (options) {
 
     const cmrOutput = _.get(options, 'reporterOptions.cmrOutput');
     const resultantOptions = _.merge({}, this.getDefaultOptions(), this.getCustomOptions(options), cmrOutput ? {cmrOutput} : null);
-  
+
     debug('options file (resultant)', resultantOptions);
     return resultantOptions;
 };
@@ -203,10 +208,14 @@ MultiReporters.prototype.getReporterOptions = function (options, name) {
     const resultantReporterOptions = _.merge({}, commonReporterOptions, customReporterOptions);
     debug('reporter options (resultant)', _name, resultantReporterOptions);
 
-    const cmrOutput = _.get(options, 'cmrOutput');
+    let cmrOutput = _.get(options, 'cmrOutput');
     if (cmrOutput) {
-        cmrOutput.split(':').forEach((cmrOutputReporter) => {
-            const [targetName, prop, output] = cmrOutputReporter.split('+');
+        if (!Array.isArray(cmrOutput)) {
+            cmrOutput = cmrOutput.split(':').map((cmrOutputReporter) => {
+                return cmrOutputReporter.split('+');
+            });
+        }
+        cmrOutput.forEach(([targetName, prop, output]) => {
             if (resultantReporterOptions[prop] && _name === targetName) {
                 resultantReporterOptions[prop] = resultantReporterOptions[prop].replace(/\{id\}/gu, output);
             }

--- a/tests/custom-internal-config-array.json
+++ b/tests/custom-internal-config-array.json
@@ -1,0 +1,7 @@
+{
+    "reporterEnabled": ["dot", "tests/custom-internal-reporter"],
+
+    "xunitReporterOptions": {
+        "output": "artifacts/test/custom-xunit.xml"
+    }
+}

--- a/tests/lib/MultiReporters.test.js
+++ b/tests/lib/MultiReporters.test.js
@@ -180,6 +180,24 @@ describe('lib/MultiReporters', function () {
                 });
             });
 
+            describe('#custom-internal-reporter (array config)', function () {
+                beforeEach(function() {
+                    options = {
+                        execute: true,
+                        reporterOptions: {
+                            configFile: 'tests/custom-internal-config-array.json'
+                        }
+                    };
+                    reporter = new mocha._reporter(runner, options);
+                });
+
+                it('return default options for "custom-internal-reporter"', function () {
+                    expect(reporter.getReporterOptions(reporter.getOptions(options), 'custom-internal-reporter')).to.be.deep.equal({
+                        id: 'default',
+                    });
+                });
+            });
+
             describe('#custom-erring-internal-reporter', function () {
                 beforeEach(function() {
                     options = {
@@ -239,6 +257,16 @@ describe('lib/MultiReporters', function () {
                 expect(reporter.getReporterOptions(reporter.getOptions({
                     reporterOptions: {
                         cmrOutput: 'tests/custom-internal-reporter+output+customName',
+                        configFile: 'tests/custom-internal-dynamic-output-config.json'
+                    }
+                }), 'mocha-junit-reporter')).to.be.deep.equal({
+                    id: 'mocha-junit-reporter',
+                    mochaFile: 'junit.xml'
+                });
+
+                expect(reporter.getReporterOptions(reporter.getOptions({
+                    reporterOptions: {
+                        cmrOutput: ['tests/custom-internal-reporter', 'output', 'customName'],
                         configFile: 'tests/custom-internal-dynamic-output-config.json'
                     }
                 }), 'mocha-junit-reporter')).to.be.deep.equal({


### PR DESCRIPTION
- Enhancement: Make it posible to supply `reporterEnabled` or `cmrOutput` as arrays; fixes #38
- Maintenance: Add `.ncurc.js` to allow `npm-check-updates` to avoid updating peerDeps by default

Re: the latter, though I know you have the Renovate bot, I tend to check repos I work with using the local `npm-check-updates`, so that commit would be helpful to avoid me accidentally trying to update peer deps (and I believe Renovate auto-closes its issues if it is superseded anyways). But if you don't want it, I can revert that part.